### PR TITLE
fix: can not build in rhel8 centos8

### DIFF
--- a/xgboost-sys/build.rs
+++ b/xgboost-sys/build.rs
@@ -63,6 +63,7 @@ fn main() {
         .expect("Couldn't write bindings.");
 
     println!("cargo:rustc-link-search={}", xgb_root.join("lib").display());
+    println!("cargo:rustc-link-search={}", xgb_root.join("lib64").display());
     println!("cargo:rustc-link-search={}", xgb_root.join("rabit/lib").display());
     println!("cargo:rustc-link-search={}", xgb_root.join("dmlc-core").display());
 
@@ -77,6 +78,7 @@ fn main() {
 
     println!("cargo:rustc-link-search=native={}", dst.display());
     println!("cargo:rustc-link-search=native={}", dst.join("lib").display());
+    println!("cargo:rustc-link-search=native={}", dst.join("lib64").display());
     println!("cargo:rustc-link-lib=static=dmlc");
     println!("cargo:rustc-link-lib=static=xgboost");
 


### PR DESCRIPTION
should fix: https://github.com/postgresml/postgresml/issues/590

@montanalow

![image](https://github.com/postgresml/rust-xgboost/assets/15976103/ef3f360e-031e-439e-a87f-99a2c793a674)
